### PR TITLE
Add EVENTS_EVENT_SIZE define for calculated queue allocations

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ void print(void *s) {
 }
 
 int main() {
-    // creates a queue with 32 events with default size
+    // creates a queue with space for 32 basic events
     equeue_t queue;
-    equeue_create(&queue, 32, 0);
+    equeue_create(&queue, 32*EVENTS_EVENT_SIZE);
 
     // events are simple callbacks
     event_call(&queue, print, "called immediately");

--- a/events.h
+++ b/events.h
@@ -17,6 +17,10 @@ extern "C" {
 #include "events_sema.h"
 
 
+// Definition of the minimum size of an event
+// This size fits the events created in the event_call set of functions.
+#define EVENTS_EVENT_SIZE (sizeof(struct event) + 3*sizeof(void*))
+
 // Event/queue structures
 struct event {
     struct event *next;
@@ -50,6 +54,7 @@ typedef struct equeue {
     events_mutex_t queuelock;
     events_mutex_t freelock;
 } equeue_t;
+
 
 // Queue operations
 //

--- a/tests/prof.c
+++ b/tests/prof.c
@@ -126,7 +126,7 @@ void events_tick_prof(void) {
 
 void event_alloc_prof(void) {
     struct equeue q;
-    equeue_create(&q, 2*32*sizeof(struct event));
+    equeue_create(&q, 32*EVENTS_EVENT_SIZE);
 
     prof_loop() {
         prof_start();
@@ -141,7 +141,7 @@ void event_alloc_prof(void) {
 
 void event_alloc_many_prof(int count) {
     struct equeue q;
-    equeue_create(&q, 2*count*sizeof(struct event));
+    equeue_create(&q, count*EVENTS_EVENT_SIZE);
 
     void *es[count];
 
@@ -166,7 +166,7 @@ void event_alloc_many_prof(int count) {
 
 void event_post_prof(void) {
     struct equeue q;
-    equeue_create(&q, 2*sizeof(struct event));
+    equeue_create(&q, EVENTS_EVENT_SIZE);
 
     prof_loop() {
         void *e = event_alloc(&q, 0);
@@ -183,7 +183,7 @@ void event_post_prof(void) {
 
 void event_post_many_prof(int count) {
     struct equeue q;
-    equeue_create(&q, 2*count*sizeof(struct event));
+    equeue_create(&q, count*EVENTS_EVENT_SIZE);
 
     for (int i = 0; i < count; i++) {
         event_call(&q, no_func, 0);
@@ -204,7 +204,7 @@ void event_post_many_prof(int count) {
 
 void event_post_future_prof(void) {
     struct equeue q;
-    equeue_create(&q, 2*sizeof(struct event));
+    equeue_create(&q, EVENTS_EVENT_SIZE);
 
     prof_loop() {
         void *e = event_alloc(&q, 0);
@@ -222,7 +222,7 @@ void event_post_future_prof(void) {
 
 void event_post_future_many_prof(int count) {
     struct equeue q;
-    equeue_create(&q, 2*count*sizeof(struct event));
+    equeue_create(&q, count*EVENTS_EVENT_SIZE);
 
     for (int i = 0; i < count; i++) {
         event_call(&q, no_func, 0);
@@ -244,7 +244,7 @@ void event_post_future_many_prof(int count) {
 
 void equeue_dispatch_prof(void) {
     struct equeue q;
-    equeue_create(&q, 2*sizeof(struct event));
+    equeue_create(&q, EVENTS_EVENT_SIZE);
 
     prof_loop() {
         event_call(&q, no_func, 0);
@@ -259,7 +259,7 @@ void equeue_dispatch_prof(void) {
 
 void equeue_dispatch_many_prof(int count) {
     struct equeue q;
-    equeue_create(&q, 2*count*sizeof(struct event));
+    equeue_create(&q, count*EVENTS_EVENT_SIZE);
 
     prof_loop() {
         for (int i = 0; i < count; i++) {
@@ -276,7 +276,7 @@ void equeue_dispatch_many_prof(int count) {
 
 void event_cancel_prof(void) {
     struct equeue q;
-    equeue_create(&q, 2*sizeof(struct event));
+    equeue_create(&q, EVENTS_EVENT_SIZE);
 
     prof_loop() {
         int id = event_call(&q, no_func, 0);
@@ -291,7 +291,7 @@ void event_cancel_prof(void) {
 
 void event_cancel_many_prof(int count) {
     struct equeue q;
-    equeue_create(&q, 2*count*sizeof(struct event));
+    equeue_create(&q, count*EVENTS_EVENT_SIZE);
 
     for (int i = 0; i < count; i++) {
         event_call(&q, no_func, 0);
@@ -309,7 +309,7 @@ void event_cancel_many_prof(int count) {
 }
 
 void event_alloc_size_prof(void) {
-    size_t size = 2*32*sizeof(struct event);
+    size_t size = 32*EVENTS_EVENT_SIZE;
 
     struct equeue q;
     equeue_create(&q, size);
@@ -321,7 +321,7 @@ void event_alloc_size_prof(void) {
 }
 
 void event_alloc_many_size_prof(int count) {
-    size_t size = 2*count*sizeof(struct event);
+    size_t size = count*EVENTS_EVENT_SIZE;
 
     struct equeue q;
     equeue_create(&q, size);
@@ -336,7 +336,7 @@ void event_alloc_many_size_prof(int count) {
 }
 
 void event_alloc_fragmented_size_prof(int count) {
-    size_t size = 2*count*sizeof(struct event);
+    size_t size = count*EVENTS_EVENT_SIZE;
 
     struct equeue q;
     equeue_create(&q, size);

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -265,7 +265,7 @@ void break_test(void) {
 // Barrage tests
 void simple_barrage_test(int N) {
     equeue_t q;
-    int err = equeue_create(&q, N * 56);
+    int err = equeue_create(&q, N*(EVENTS_EVENT_SIZE+sizeof(struct timing)));
     test_assert(!err);
 
     for (int i = 0; i < N; i++) {
@@ -288,7 +288,8 @@ void simple_barrage_test(int N) {
 
 void fragmenting_barrage_test(int N) {
     equeue_t q;
-    int err = equeue_create(&q, N * 1000);
+    int err = equeue_create(&q,
+            2*N*(EVENTS_EVENT_SIZE+sizeof(struct fragment)+N*sizeof(int)));
     test_assert(!err);
 
     for (int i = 0; i < N; i++) {
@@ -325,7 +326,7 @@ static void *ethread_dispatch(void *p) {
 
 void multithreaded_barrage_test(int N) {
     equeue_t q;
-    int err = equeue_create(&q, N * 56);
+    int err = equeue_create(&q, N*(EVENTS_EVENT_SIZE+sizeof(struct timing)));
     test_assert(!err);
 
     struct ethread t;


### PR DESCRIPTION
In the events library, the structure of an event is correctly not part of the public api. Unfortunately, this makes it difficult to calculate the space needed for a finite set of events.

In this pr, EVENTS_EVENT_SIZE is defined as the space needed for the smallest event, the event allocated in event_call.

This allows queues to be created based on a number of events:
``` c
equeue_create(&q, 12 * (EVENTS_EVENT_SIZE+sizeof(struct context)));
```