### PR TITLE
Rename event -> equeue for functions operating on queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ int main() {
     equeue_create(&queue, 32*EVENTS_EVENT_SIZE);
 
     // events are simple callbacks
-    event_call(&queue, print, "called immediately");
-    event_call_in(&queue, print, "called in 2 seconds", 2000);
-    event_call_every(&queue, print, "called every 1 seconds", 1000);
+    equeue_call(&queue, print, "called immediately");
+    equeue_call_in(&queue, print, "called in 2 seconds", 2000);
+    equeue_call_every(&queue, print, "called every 1 seconds", 1000);
 
     // events are executed when dispatch is called
     equeue_dispatch(&queue, 3000);

--- a/events.h
+++ b/events.h
@@ -80,26 +80,26 @@ void equeue_break(equeue_t *queue);
 // Passed callback will be executed in the associated equeue's
 // dispatch call with the data pointer passed unmodified
 //
-// event_call       - Immediately post an event to the queue
-// event_call_in    - Post an event after a specified time in milliseconds
-// event_call_every - Post an event periodically in milliseconds
+// equeue_call       - Immediately post an event to the queue
+// equeue_call_in    - Post an event after a specified time in milliseconds
+// equeue_call_every - Post an event periodically in milliseconds
 //
 // These calls will result in 0 if no memory is available, otherwise they
-// will result in a unique identifier that can be passed to event_cancel.
-int event_call(equeue_t *queue, void (*cb)(void *), void *data);
-int event_call_in(equeue_t *queue, int ms, void (*cb)(void *), void *data);
-int event_call_every(equeue_t *queue, int ms, void (*cb)(void *), void *data);
+// will result in a unique identifier that can be passed to equeue_cancel.
+int equeue_call(equeue_t *queue, void (*cb)(void *), void *data);
+int equeue_call_in(equeue_t *queue, int ms, void (*cb)(void *), void *data);
+int equeue_call_every(equeue_t *queue, int ms, void (*cb)(void *), void *data);
 
 // Events with queue handled blocks of memory
 //
-// Argument to event_post must point to a result of a event_alloc call
+// Argument to equeue_post must point to a result of a equeue_alloc call
 // and the associated memory is automatically freed after the event
 // is dispatched.
 //
-// event_alloc will result in null if no memory is available
+// equeue_alloc will result in null if no memory is available
 // or the requested size is less than the size passed to equeue_create.
-void *event_alloc(equeue_t *queue, unsigned size);
-void event_dealloc(equeue_t *queue, void *event);
+void *equeue_alloc(equeue_t *queue, unsigned size);
+void equeue_dealloc(equeue_t *queue, void *event);
 
 // Configure an allocated event
 // 
@@ -112,21 +112,21 @@ void event_dtor(void *event, void (*dtor)(void *));
 
 // Post an allocted event to the event queue
 //
-// Argument to event_post must point to a result of a event_alloc call
+// Argument to equeue_post must point to a result of a equeue_alloc call
 // and the associated memory is automatically freed after the event
 // is dispatched.
 //
 // This call results in an unique identifier that can be passed to
-// event_cancel.
-int event_post(equeue_t *queue, void (*cb)(void *), void *event);
+// equeue_cancel.
+int equeue_post(equeue_t *queue, void (*cb)(void *), void *event);
 
 // Cancel events that are in flight
 //
-// Every event_call function returns a non-negative identifier on success
+// Every equeue_call function returns a non-negative identifier on success
 // that can be used to cancel an in-flight event. If the event has already
 // been dispatched or does not exist, no error occurs. Note, this can not
 // stop a currently executing event
-void event_cancel(equeue_t *queue, int event);
+void equeue_cancel(equeue_t *queue, int event);
 
 
 #ifdef __cplusplus

--- a/tests/prof.c
+++ b/tests/prof.c
@@ -124,119 +124,119 @@ void events_tick_prof(void) {
     }
 }
 
-void event_alloc_prof(void) {
+void equeue_alloc_prof(void) {
     struct equeue q;
     equeue_create(&q, 32*EVENTS_EVENT_SIZE);
 
     prof_loop() {
         prof_start();
-        void *e = event_alloc(&q, 8 * sizeof(int));
+        void *e = equeue_alloc(&q, 8 * sizeof(int));
         prof_stop();
 
-        event_dealloc(&q, e);
+        equeue_dealloc(&q, e);
     }
 
     equeue_destroy(&q);
 }
 
-void event_alloc_many_prof(int count) {
+void equeue_alloc_many_prof(int count) {
     struct equeue q;
     equeue_create(&q, count*EVENTS_EVENT_SIZE);
 
     void *es[count];
 
     for (int i = 0; i < count; i++) {
-        es[i] = event_alloc(&q, (i % 4) * sizeof(int));
+        es[i] = equeue_alloc(&q, (i % 4) * sizeof(int));
     }
 
     for (int i = 0; i < count; i++) {
-        event_dealloc(&q, es[i]);
+        equeue_dealloc(&q, es[i]);
     }
 
     prof_loop() {
         prof_start();
-        void *e = event_alloc(&q, 8 * sizeof(int));
+        void *e = equeue_alloc(&q, 8 * sizeof(int));
         prof_stop();
 
-        event_dealloc(&q, e);
+        equeue_dealloc(&q, e);
     }
 
     equeue_destroy(&q);
 }
 
-void event_post_prof(void) {
+void equeue_post_prof(void) {
     struct equeue q;
     equeue_create(&q, EVENTS_EVENT_SIZE);
 
     prof_loop() {
-        void *e = event_alloc(&q, 0);
+        void *e = equeue_alloc(&q, 0);
 
         prof_start();
-        int id = event_post(&q, no_func, e);
+        int id = equeue_post(&q, no_func, e);
         prof_stop();
 
-        event_cancel(&q, id);
+        equeue_cancel(&q, id);
     }
 
     equeue_destroy(&q);
 }
 
-void event_post_many_prof(int count) {
+void equeue_post_many_prof(int count) {
     struct equeue q;
     equeue_create(&q, count*EVENTS_EVENT_SIZE);
 
     for (int i = 0; i < count; i++) {
-        event_call(&q, no_func, 0);
+        equeue_call(&q, no_func, 0);
     }
 
     prof_loop() {
-        void *e = event_alloc(&q, 0);
+        void *e = equeue_alloc(&q, 0);
 
         prof_start();
-        int id = event_post(&q, no_func, e);
+        int id = equeue_post(&q, no_func, e);
         prof_stop();
 
-        event_cancel(&q, id);
+        equeue_cancel(&q, id);
     }
 
     equeue_destroy(&q);
 }
 
-void event_post_future_prof(void) {
+void equeue_post_future_prof(void) {
     struct equeue q;
     equeue_create(&q, EVENTS_EVENT_SIZE);
 
     prof_loop() {
-        void *e = event_alloc(&q, 0);
+        void *e = equeue_alloc(&q, 0);
         event_delay(e, 1000);
 
         prof_start();
-        int id = event_post(&q, no_func, e);
+        int id = equeue_post(&q, no_func, e);
         prof_stop();
 
-        event_cancel(&q, id);
+        equeue_cancel(&q, id);
     }
 
     equeue_destroy(&q);
 }
 
-void event_post_future_many_prof(int count) {
+void equeue_post_future_many_prof(int count) {
     struct equeue q;
     equeue_create(&q, count*EVENTS_EVENT_SIZE);
 
     for (int i = 0; i < count; i++) {
-        event_call(&q, no_func, 0);
+        equeue_call(&q, no_func, 0);
     }
 
     prof_loop() {
-        void *e = event_alloc(&q, 0);
+        void *e = equeue_alloc(&q, 0);
         event_delay(e, 1000);
 
         prof_start();
-        int id = event_post(&q, no_func, e);
+        int id = equeue_post(&q, no_func, e);
         prof_stop();
 
-        event_cancel(&q, id);
+        equeue_cancel(&q, id);
     }
 
     equeue_destroy(&q);
@@ -247,7 +247,7 @@ void equeue_dispatch_prof(void) {
     equeue_create(&q, EVENTS_EVENT_SIZE);
 
     prof_loop() {
-        event_call(&q, no_func, 0);
+        equeue_call(&q, no_func, 0);
 
         prof_start();
         equeue_dispatch(&q, 0);
@@ -263,7 +263,7 @@ void equeue_dispatch_many_prof(int count) {
 
     prof_loop() {
         for (int i = 0; i < count; i++) {
-            event_call(&q, no_func, 0);
+            equeue_call(&q, no_func, 0);
         }
 
         prof_start();
@@ -274,60 +274,60 @@ void equeue_dispatch_many_prof(int count) {
     equeue_destroy(&q);
 }
 
-void event_cancel_prof(void) {
+void equeue_cancel_prof(void) {
     struct equeue q;
     equeue_create(&q, EVENTS_EVENT_SIZE);
 
     prof_loop() {
-        int id = event_call(&q, no_func, 0);
+        int id = equeue_call(&q, no_func, 0);
 
         prof_start();
-        event_cancel(&q, id);
+        equeue_cancel(&q, id);
         prof_stop();
     }
 
     equeue_destroy(&q);
 }
 
-void event_cancel_many_prof(int count) {
+void equeue_cancel_many_prof(int count) {
     struct equeue q;
     equeue_create(&q, count*EVENTS_EVENT_SIZE);
 
     for (int i = 0; i < count; i++) {
-        event_call(&q, no_func, 0);
+        equeue_call(&q, no_func, 0);
     }
 
     prof_loop() {
-        int id = event_call(&q, no_func, 0);
+        int id = equeue_call(&q, no_func, 0);
 
         prof_start();
-        event_cancel(&q, id);
+        equeue_cancel(&q, id);
         prof_stop();
     }
 
     equeue_destroy(&q);
 }
 
-void event_alloc_size_prof(void) {
+void equeue_alloc_size_prof(void) {
     size_t size = 32*EVENTS_EVENT_SIZE;
 
     struct equeue q;
     equeue_create(&q, size);
-    event_alloc(&q, 0);
+    equeue_alloc(&q, 0);
 
     prof_result(size - q.slab.size, "bytes");
 
     equeue_destroy(&q);
 }
 
-void event_alloc_many_size_prof(int count) {
+void equeue_alloc_many_size_prof(int count) {
     size_t size = count*EVENTS_EVENT_SIZE;
 
     struct equeue q;
     equeue_create(&q, size);
 
     for (int i = 0; i < count; i++) {
-        event_alloc(&q, (i % 4) * sizeof(int));
+        equeue_alloc(&q, (i % 4) * sizeof(int));
     }
 
     prof_result(size - q.slab.size, "bytes");
@@ -335,7 +335,7 @@ void event_alloc_many_size_prof(int count) {
     equeue_destroy(&q);
 }
 
-void event_alloc_fragmented_size_prof(int count) {
+void equeue_alloc_fragmented_size_prof(int count) {
     size_t size = count*EVENTS_EVENT_SIZE;
 
     struct equeue q;
@@ -344,23 +344,23 @@ void event_alloc_fragmented_size_prof(int count) {
     void *es[count];
 
     for (int i = 0; i < count; i++) {
-        es[i] = event_alloc(&q, (i % 4) * sizeof(int));
+        es[i] = equeue_alloc(&q, (i % 4) * sizeof(int));
     }
 
     for (int i = 0; i < count; i++) {
-        event_dealloc(&q, es[i]);
+        equeue_dealloc(&q, es[i]);
     }
 
     for (int i = count-1; i >= 0; i--) {
-        es[i] = event_alloc(&q, (i % 4) * sizeof(int));
+        es[i] = equeue_alloc(&q, (i % 4) * sizeof(int));
     }
 
     for (int i = count-1; i >= 0; i--) {
-        event_dealloc(&q, es[i]);
+        equeue_dealloc(&q, es[i]);
     }
 
     for (int i = 0; i < count; i++) {
-        event_alloc(&q, (i % 4) * sizeof(int));
+        equeue_alloc(&q, (i % 4) * sizeof(int));
     }
 
     prof_result(size - q.slab.size, "bytes");
@@ -376,21 +376,21 @@ int main() {
     prof_baseline(baseline_prof);
 
     prof_measure(events_tick_prof);
-    prof_measure(event_alloc_prof);
-    prof_measure(event_post_prof);
-    prof_measure(event_post_future_prof);
+    prof_measure(equeue_alloc_prof);
+    prof_measure(equeue_post_prof);
+    prof_measure(equeue_post_future_prof);
     prof_measure(equeue_dispatch_prof);
-    prof_measure(event_cancel_prof);
+    prof_measure(equeue_cancel_prof);
 
-    prof_measure(event_alloc_many_prof, 1000);
-    prof_measure(event_post_many_prof, 1000);
-    prof_measure(event_post_future_many_prof, 1000);
+    prof_measure(equeue_alloc_many_prof, 1000);
+    prof_measure(equeue_post_many_prof, 1000);
+    prof_measure(equeue_post_future_many_prof, 1000);
     prof_measure(equeue_dispatch_many_prof, 100);
-    prof_measure(event_cancel_many_prof, 100);
+    prof_measure(equeue_cancel_many_prof, 100);
 
-    prof_measure(event_alloc_size_prof);
-    prof_measure(event_alloc_many_size_prof, 1000);
-    prof_measure(event_alloc_fragmented_size_prof, 1000);
+    prof_measure(equeue_alloc_size_prof);
+    prof_measure(equeue_alloc_many_size_prof, 1000);
+    prof_measure(equeue_alloc_fragmented_size_prof, 1000);
 
     printf("done!\n");
 }


### PR DESCRIPTION
Indicates primary object these functions operate on, which is the queue.
```
event_call       -> equeue_call
event_call_in    -> equeue_call_in
event_call_every -> equeue_call_every
event_alloc      -> equeue_alloc
event_dealloc    -> equeue_dealloc
event_post       -> equeue_post
event_cancel     -> equeue_cancel
```

These were initially prefixed with event, since they associated with single events in the queue. However it became quickly apparent that this just led to confusion.

Unfortunately, the event prefix hasn't been completely removed and remains in the funtions that directly operate on events:

- event_delay
- event_period
- event_dtor

@kilogram, thoughts? I'm open to alternative names for the event_delay/event_period functions.