### PR TITLE
Rename the events library to the equeue library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TARGET = libevents.a
+TARGET = libequeue.a
 
 CC = gcc
 AR = ar

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
-## Events ##
+## The equeue library ##
 
-The events library provides a flexible event queue implementation
-that acts as a drop in scheduler and framework for composable event
-loops.
+The equeue library provides a composable event queue implementation
+that acts as a drop in scheduler and event framework.
 
 ``` c
-#include "events.h"
+#include "equeue.h"
 #include <stdio.h>
 
 void print(void *s) {
@@ -15,12 +14,12 @@ void print(void *s) {
 int main() {
     // creates a queue with space for 32 basic events
     equeue_t queue;
-    equeue_create(&queue, 32*EVENTS_EVENT_SIZE);
+    equeue_create(&queue, 32*EQUEUE_EVENT_SIZE);
 
     // events are simple callbacks
     equeue_call(&queue, print, "called immediately");
-    equeue_call_in(&queue, print, "called in 2 seconds", 2000);
-    equeue_call_every(&queue, print, "called every 1 seconds", 1000);
+    equeue_call_in(&queue, 2000, print, "called in 2 seconds");
+    equeue_call_every(&queue, 1000, print, "called every 1 seconds");
 
     // events are executed when dispatch is called
     equeue_dispatch(&queue, 3000);
@@ -32,14 +31,14 @@ int main() {
 }
 ```
 
-The events library can be used for normal event loops, however it also
-supports multithreaded environments. More information on the idea
-behind composable event loops 
+The equeue library can be used for a normal event loops, however it also
+supports composition and multithreaded environments. More information on
+the idea behind composable event loops 
 [here](https://gist.github.com/geky/4969d940f1bd5596bdc10e79093e2553).
 
 ## Tests ##
 
-The events library uses a set of local tests based on the posix implementation.
+The equeue library uses a set of local tests based on the posix implementation.
 
 Runtime tests are located in [tests.c](tests/tests.c):
 
@@ -63,6 +62,6 @@ cat results.txt | make prof
 ## Porting ##
 
 The events library requires a small porting layer:
-- [events_tick](events_tick.h) - monotonic counter
-- [events_mutex](events_mutex.h) - non-recursive mutex
-- [events_sema](events_sema.h) - binary semaphore
+- [equeue_tick](equeue_tick.h) - monotonic counter
+- [equeue_mutex](equeue_mutex.h) - non-recursive mutex
+- [equeue_sema](equeue_sema.h) - binary semaphore

--- a/equeue.h
+++ b/equeue.h
@@ -4,26 +4,26 @@
  * Copyright (c) 2016 Christopher Haster
  * Distributed under the MIT license
  */
-#ifndef EVENTS_H
-#define EVENTS_H
+#ifndef EQUEUE_H
+#define EQUEUE_H
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 // System specific files
-#include "events_tick.h"
-#include "events_mutex.h"
-#include "events_sema.h"
+#include "equeue_tick.h"
+#include "equeue_mutex.h"
+#include "equeue_sema.h"
 
 
 // Definition of the minimum size of an event
 // This size fits the events created in the event_call set of functions.
-#define EVENTS_EVENT_SIZE (sizeof(struct event) + 3*sizeof(void*))
+#define EQUEUE_EVENT_SIZE (sizeof(struct equeue_event) + 3*sizeof(void*))
 
 // Event/queue structures
-struct event {
-    struct event *next;
+struct equeue_event {
+    struct equeue_event *next;
     int id;
     unsigned target;
     int period;
@@ -34,7 +34,7 @@ struct event {
 };
 
 typedef struct equeue {
-    struct event *queue;
+    struct equeue_event *queue;
     int next_id;
 
     void *buffer;
@@ -48,11 +48,11 @@ typedef struct equeue {
         unsigned char *data;
     } slab;
 
-    struct event break_;
+    struct equeue_event break_;
 
-    events_sema_t eventsema;
-    events_mutex_t queuelock;
-    events_mutex_t freelock;
+    equeue_sema_t eventsema;
+    equeue_mutex_t queuelock;
+    equeue_mutex_t freelock;
 } equeue_t;
 
 
@@ -103,12 +103,12 @@ void equeue_dealloc(equeue_t *queue, void *event);
 
 // Configure an allocated event
 // 
-// event_delay  - Specify a millisecond delay before posting an event
-// event_period - Specify a millisecond period to repeatedly post an event
-// event_dtor   - Specify a destructor to run before the memory is deallocated
-void event_delay(void *event, int ms);
-void event_period(void *event, int ms);
-void event_dtor(void *event, void (*dtor)(void *));
+// equeue_event_delay  - Millisecond delay before posting an event
+// equeue_event_period - Millisecond period to repeatedly post an event
+// equeue_event_dtor   - Destructor to run when the event is deallocated
+void equeue_event_delay(void *event, int ms);
+void equeue_event_period(void *event, int ms);
+void equeue_event_dtor(void *event, void (*dtor)(void *));
 
 // Post an allocted event to the event queue
 //

--- a/equeue_mbed.cpp
+++ b/equeue_mbed.cpp
@@ -7,9 +7,9 @@
  */
 #if defined(__MBED__)
 
-#include "events_tick.h"
-#include "events_sema.h"
-#include "events_mutex.h"
+#include "equeue_tick.h"
+#include "equeue_sema.h"
+#include "equeue_mutex.h"
 
 #include <stdbool.h>
 #include "mbed.h"
@@ -42,21 +42,21 @@ private:
     Ticker _ticker;
 } gticker;
 
-unsigned events_tick() {
+unsigned equeue_tick() {
     return gticker.tick();
 }
 
 
 // Mutex operations
-int events_mutex_create(events_mutex_t *m) { return 0; }
-void events_mutex_destroy(events_mutex_t *m) { }
+int equeue_mutex_create(equeue_mutex_t *m) { return 0; }
+void equeue_mutex_destroy(equeue_mutex_t *m) { }
 
-void events_mutex_lock(events_mutex_t *m) {
+void equeue_mutex_lock(equeue_mutex_t *m) {
     *m = __get_PRIMASK();
     __disable_irq();
 }
 
-void events_mutex_unlock(events_mutex_t *m) {
+void equeue_mutex_unlock(equeue_mutex_t *m) {
     __set_PRIMASK(*m);
 }
 
@@ -64,24 +64,24 @@ void events_mutex_unlock(events_mutex_t *m) {
 // Semaphore operations
 #ifdef MBED_CONF_RTOS_PRESENT
 
-static inline Semaphore *sema(events_sema_t *s) {
+static inline Semaphore *sema(equeue_sema_t *s) {
     return static_cast<Semaphore*>(*s);
 }
 
-int events_sema_create(events_sema_t *s) {
+int equeue_sema_create(equeue_sema_t *s) {
     *s = new Semaphore(0);
     return sema(s) ? 0 : -1;
 }
 
-void events_sema_destroy(events_sema_t *s) {
+void equeue_sema_destroy(equeue_sema_t *s) {
     delete sema(s);
 }
 
-void events_sema_release(events_sema_t *s) {
+void equeue_sema_release(equeue_sema_t *s) {
     sema(s)->release();
 }
 
-bool events_sema_wait(events_sema_t *s, int ms) {
+bool equeue_sema_wait(equeue_sema_t *s, int ms) {
     int t = sema(s)->wait(ms < 0 ? osWaitForever : ms);
     return t > 0;
 }
@@ -89,15 +89,15 @@ bool events_sema_wait(events_sema_t *s, int ms) {
 #else
 
 // Semaphore operations
-int events_sema_create(events_sema_t *s) { return 0; }
-void events_sema_destroy(events_sema_t *s) {}
-void events_sema_release(events_sema_t *s) {}
+int equeue_sema_create(equeue_sema_t *s) { return 0; }
+void equeue_sema_destroy(equeue_sema_t *s) {}
+void equeue_sema_release(equeue_sema_t *s) {}
 
-static void events_sema_wakeup() {}
+static void equeue_sema_wakeup() {}
 
-bool events_sema_wait(events_sema_t *s, int ms) {
+bool equeue_sema_wait(equeue_sema_t *s, int ms) {
     Timeout timeout;
-    timeout.attach_us(events_sema_wakeup, ms*1000);
+    timeout.attach_us(equeue_sema_wakeup, ms*1000);
 
     __WFI();
 

--- a/equeue_mutex.h
+++ b/equeue_mutex.h
@@ -4,8 +4,8 @@
  * Copyright (c) 2016 Christopher Haster
  * Distributed under the MIT license
  */
-#ifndef EVENTS_MUTEX_H
-#define EVENTS_MUTEX_H
+#ifndef EQUEUE_MUTEX_H
+#define EQUEUE_MUTEX_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -19,17 +19,17 @@ extern "C" {
 // interrupt contexts.
 #if defined(__unix__)
 #include <pthread.h>
-typedef pthread_mutex_t events_mutex_t;
+typedef pthread_mutex_t equeue_mutex_t;
 #elif defined(__MBED__)
-typedef unsigned events_mutex_t;
+typedef unsigned equeue_mutex_t;
 #endif
 
 
 // Mutex operations
-int events_mutex_create(events_mutex_t *mutex);
-void events_mutex_destroy(events_mutex_t *mutex);
-void events_mutex_lock(events_mutex_t *mutex);
-void events_mutex_unlock(events_mutex_t *mutex);
+int equeue_mutex_create(equeue_mutex_t *mutex);
+void equeue_mutex_destroy(equeue_mutex_t *mutex);
+void equeue_mutex_lock(equeue_mutex_t *mutex);
+void equeue_mutex_unlock(equeue_mutex_t *mutex);
 
 
 #ifdef __cplusplus

--- a/equeue_posix.c
+++ b/equeue_posix.c
@@ -6,16 +6,16 @@
  */
 #if defined(__unix__)
 
-#include "events_tick.h"
-#include "events_sema.h"
-#include "events_mutex.h"
+#include "equeue_tick.h"
+#include "equeue_sema.h"
+#include "equeue_mutex.h"
 
 #include <time.h>
 #include <sys/time.h>
 
 
 // Tick operations
-unsigned events_tick(void) {
+unsigned equeue_tick(void) {
     struct timeval tv;
     gettimeofday(&tv, 0);
     return (unsigned)(tv.tv_sec*1000 + tv.tv_usec/1000);
@@ -23,41 +23,41 @@ unsigned events_tick(void) {
 
 
 // Mutex operations
-int events_mutex_create(events_mutex_t *m) {
+int equeue_mutex_create(equeue_mutex_t *m) {
     return pthread_mutex_init(m, 0);
 }
 
-void events_mutex_destroy(events_mutex_t *m) {
+void equeue_mutex_destroy(equeue_mutex_t *m) {
     pthread_mutex_destroy(m);
 }
 
-void events_mutex_lock(events_mutex_t *m) {
+void equeue_mutex_lock(equeue_mutex_t *m) {
     pthread_mutex_lock(m);
 }
 
-void events_mutex_unlock(events_mutex_t *m) {
+void equeue_mutex_unlock(equeue_mutex_t *m) {
     pthread_mutex_unlock(m);
 }
 
 
 // Semaphore operations
-int events_sema_create(events_sema_t *s) {
+int equeue_sema_create(equeue_sema_t *s) {
     return sem_init(s, 0, 0);
 }
 
-void events_sema_destroy(events_sema_t *s) {
+void equeue_sema_destroy(equeue_sema_t *s) {
     sem_destroy(s);
 }
 
-void events_sema_release(events_sema_t *s) {
+void equeue_sema_release(equeue_sema_t *s) {
     sem_post(s);
 }
 
-bool events_sema_wait(events_sema_t *s, int ms) {
+bool equeue_sema_wait(equeue_sema_t *s, int ms) {
     if (ms < 0) {
         return !sem_wait(s);
     } else {
-        ms += events_tick();
+        ms += equeue_tick();
         struct timespec ts = {
             .tv_sec = ms/1000,
             .tv_nsec = ms*1000000,

--- a/equeue_sema.h
+++ b/equeue_sema.h
@@ -4,8 +4,8 @@
  * Copyright (c) 2016 Christopher Haster
  * Distributed under the MIT license
  */
-#ifndef EVENTS_SEMA_H
-#define EVENTS_SEMA_H
+#ifndef EQUEUE_SEMA_H
+#define EQUEUE_SEMA_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -20,21 +20,21 @@ extern "C" {
 // however a regular semaphore is sufficient.
 #if defined(__unix__)
 #include <semaphore.h>
-typedef sem_t events_sema_t;
+typedef sem_t equeue_sema_t;
 #elif defined(__MBED__)
 #ifdef MBED_CONF_RTOS_PRESENT
-typedef void *events_sema_t;
+typedef void *equeue_sema_t;
 #else
-typedef struct {} events_sema_t;
+typedef struct {} equeue_sema_t;
 #endif
 #endif
 
 
 // Semaphore operations
-int events_sema_create(events_sema_t *sema);
-void events_sema_destroy(events_sema_t *sema);
-void events_sema_release(events_sema_t *sema);
-bool events_sema_wait(events_sema_t *sema, int ms);
+int equeue_sema_create(equeue_sema_t *sema);
+void equeue_sema_destroy(equeue_sema_t *sema);
+void equeue_sema_release(equeue_sema_t *sema);
+bool equeue_sema_wait(equeue_sema_t *sema, int ms);
 
 
 #ifdef __cplusplus

--- a/equeue_tick.h
+++ b/equeue_tick.h
@@ -4,8 +4,8 @@
  * Copyright (c) 2016 Christopher Haster
  * Distributed under the MIT license
  */
-#ifndef EVENTS_TICK_H
-#define EVENTS_TICK_H
+#ifndef EQUEUE_TICK_H
+#define EQUEUE_TICK_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -16,7 +16,7 @@ extern "C" {
 //
 // Returns a tick that is incremented every millisecond,
 // must intentionally overflow to 0 after 2^32-1
-unsigned events_tick(void);
+unsigned equeue_tick(void);
 
 
 #ifdef __cplusplus

--- a/tests/prof.c
+++ b/tests/prof.c
@@ -4,7 +4,7 @@
  * Copyright (c) 2016 Christopher Haster
  * Distributed under the MIT license
  */
-#include "events.h"
+#include "equeue.h"
 #include <unistd.h>
 #include <stdio.h>
 #include <setjmp.h>
@@ -115,18 +115,18 @@ void baseline_prof(void) {
     }
 }
 
-void events_tick_prof(void) {
+void equeue_tick_prof(void) {
     prof_volatile(unsigned) res;
     prof_loop() {
         prof_start();
-        res = events_tick();
+        res = equeue_tick();
         prof_stop();
     }
 }
 
 void equeue_alloc_prof(void) {
     struct equeue q;
-    equeue_create(&q, 32*EVENTS_EVENT_SIZE);
+    equeue_create(&q, 32*EQUEUE_EVENT_SIZE);
 
     prof_loop() {
         prof_start();
@@ -141,7 +141,7 @@ void equeue_alloc_prof(void) {
 
 void equeue_alloc_many_prof(int count) {
     struct equeue q;
-    equeue_create(&q, count*EVENTS_EVENT_SIZE);
+    equeue_create(&q, count*EQUEUE_EVENT_SIZE);
 
     void *es[count];
 
@@ -166,7 +166,7 @@ void equeue_alloc_many_prof(int count) {
 
 void equeue_post_prof(void) {
     struct equeue q;
-    equeue_create(&q, EVENTS_EVENT_SIZE);
+    equeue_create(&q, EQUEUE_EVENT_SIZE);
 
     prof_loop() {
         void *e = equeue_alloc(&q, 0);
@@ -183,7 +183,7 @@ void equeue_post_prof(void) {
 
 void equeue_post_many_prof(int count) {
     struct equeue q;
-    equeue_create(&q, count*EVENTS_EVENT_SIZE);
+    equeue_create(&q, count*EQUEUE_EVENT_SIZE);
 
     for (int i = 0; i < count; i++) {
         equeue_call(&q, no_func, 0);
@@ -204,11 +204,11 @@ void equeue_post_many_prof(int count) {
 
 void equeue_post_future_prof(void) {
     struct equeue q;
-    equeue_create(&q, EVENTS_EVENT_SIZE);
+    equeue_create(&q, EQUEUE_EVENT_SIZE);
 
     prof_loop() {
         void *e = equeue_alloc(&q, 0);
-        event_delay(e, 1000);
+        equeue_event_delay(e, 1000);
 
         prof_start();
         int id = equeue_post(&q, no_func, e);
@@ -222,7 +222,7 @@ void equeue_post_future_prof(void) {
 
 void equeue_post_future_many_prof(int count) {
     struct equeue q;
-    equeue_create(&q, count*EVENTS_EVENT_SIZE);
+    equeue_create(&q, count*EQUEUE_EVENT_SIZE);
 
     for (int i = 0; i < count; i++) {
         equeue_call(&q, no_func, 0);
@@ -230,7 +230,7 @@ void equeue_post_future_many_prof(int count) {
 
     prof_loop() {
         void *e = equeue_alloc(&q, 0);
-        event_delay(e, 1000);
+        equeue_event_delay(e, 1000);
 
         prof_start();
         int id = equeue_post(&q, no_func, e);
@@ -244,7 +244,7 @@ void equeue_post_future_many_prof(int count) {
 
 void equeue_dispatch_prof(void) {
     struct equeue q;
-    equeue_create(&q, EVENTS_EVENT_SIZE);
+    equeue_create(&q, EQUEUE_EVENT_SIZE);
 
     prof_loop() {
         equeue_call(&q, no_func, 0);
@@ -259,7 +259,7 @@ void equeue_dispatch_prof(void) {
 
 void equeue_dispatch_many_prof(int count) {
     struct equeue q;
-    equeue_create(&q, count*EVENTS_EVENT_SIZE);
+    equeue_create(&q, count*EQUEUE_EVENT_SIZE);
 
     prof_loop() {
         for (int i = 0; i < count; i++) {
@@ -276,7 +276,7 @@ void equeue_dispatch_many_prof(int count) {
 
 void equeue_cancel_prof(void) {
     struct equeue q;
-    equeue_create(&q, EVENTS_EVENT_SIZE);
+    equeue_create(&q, EQUEUE_EVENT_SIZE);
 
     prof_loop() {
         int id = equeue_call(&q, no_func, 0);
@@ -291,7 +291,7 @@ void equeue_cancel_prof(void) {
 
 void equeue_cancel_many_prof(int count) {
     struct equeue q;
-    equeue_create(&q, count*EVENTS_EVENT_SIZE);
+    equeue_create(&q, count*EQUEUE_EVENT_SIZE);
 
     for (int i = 0; i < count; i++) {
         equeue_call(&q, no_func, 0);
@@ -309,7 +309,7 @@ void equeue_cancel_many_prof(int count) {
 }
 
 void equeue_alloc_size_prof(void) {
-    size_t size = 32*EVENTS_EVENT_SIZE;
+    size_t size = 32*EQUEUE_EVENT_SIZE;
 
     struct equeue q;
     equeue_create(&q, size);
@@ -321,7 +321,7 @@ void equeue_alloc_size_prof(void) {
 }
 
 void equeue_alloc_many_size_prof(int count) {
-    size_t size = count*EVENTS_EVENT_SIZE;
+    size_t size = count*EQUEUE_EVENT_SIZE;
 
     struct equeue q;
     equeue_create(&q, size);
@@ -336,7 +336,7 @@ void equeue_alloc_many_size_prof(int count) {
 }
 
 void equeue_alloc_fragmented_size_prof(int count) {
-    size_t size = count*EVENTS_EVENT_SIZE;
+    size_t size = count*EQUEUE_EVENT_SIZE;
 
     struct equeue q;
     equeue_create(&q, size);
@@ -375,7 +375,7 @@ int main() {
 
     prof_baseline(baseline_prof);
 
-    prof_measure(events_tick_prof);
+    prof_measure(equeue_tick_prof);
     prof_measure(equeue_alloc_prof);
     prof_measure(equeue_post_prof);
     prof_measure(equeue_post_future_prof);


### PR DESCRIPTION
**note: upon merge, this repo will be renamed to equeue**

- Differentiates the equeue library from other event queue libraries that don't focus on composability (libev, libevent)
- Emphasizes core component of the equeue library
- Gives obvious prefix for public symbols
- Maximizes the vowel to consonant ratio in the name

File changes:
```
events.* -> equeue.*
events_*.* -> equeue_*.*
```

Define changes:
```
EVENTS_* -> EQUEUE_*
```

Function changes:
```
events_tick_* -> equeue_tick_*
events_mutex_* -> equeue_mutex_*
events_sema_* -> equeue_sema_*
event_* -> equeue_event_*
```

@kilogram, @theotherjimmy, @kegilbert thoughts?